### PR TITLE
KiCad Quality of Life Improvements: Fix symbol footprint filters, swi…

### DIFF
--- a/KiCad/RP2xxx_Stamp.kicad_sym
+++ b/KiCad/RP2xxx_Stamp.kicad_sym
@@ -49,7 +49,7 @@
 				(hide yes)
 			)
 		)
-		(property "ki_fp_filters" "RP2xxx_Stamp"
+		(property "ki_fp_filters" "RP2xxx_Stamp*"
 			(at 0 0 0)
 			(effects
 				(font
@@ -872,7 +872,7 @@
 				)
 			)
 		)
-		(property "ki_fp_filters" "RP2xxx_Stamp_XL"
+		(property "ki_fp_filters" "RP2xxx_Stamp_XL*"
 			(at 0 0 0)
 			(effects
 				(font
@@ -2063,7 +2063,7 @@
 				(hide yes)
 			)
 		)
-		(property "ki_fp_filters" "RP2xxx_Stamp"
+		(property "ki_fp_filters" "RP2xxx_Stamp*"
 			(at 0 0 0)
 			(effects
 				(font

--- a/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_FlexyPin.kicad_mod
+++ b/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_FlexyPin.kicad_mod
@@ -2727,7 +2727,7 @@
 			(xyz 0 0 90)
 		)
 	)
-	(model "${KIPRJMOD}/rp2xxx_stamp_footprints/KiCad/RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
+	(model "../RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
 		(offset
 			(xyz 0 0 0)
 		)

--- a/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_SMD.kicad_mod
+++ b/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_SMD.kicad_mod
@@ -727,7 +727,7 @@
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(uuid "dcedf0ba-9e2d-4a5b-aa66-1d8687d3a30b")
 	)
-	(model "${KIPRJMOD}/rp2xxx_stamp_footprints/KiCad/RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
+	(model "../RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
 		(offset
 			(xyz 0 0 0)
 		)

--- a/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_THT.kicad_mod
+++ b/KiCad/RP2xxx_Stamp.pretty/RP2xxx_Stamp_XL_THT.kicad_mod
@@ -1207,7 +1207,7 @@
 		(remove_unused_layers no)
 		(uuid "878f8b57-c369-4275-afc1-66f983c27c02")
 	)
-	(model "${KIPRJMOD}/rp2xxx_stamp_footprints/KiCad/RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
+	(model "../RP2xxx_Stamp.3dshapes/RP2350_Stamp_XL.step"
 		(offset
 			(xyz 0 0 0)
 		)


### PR DESCRIPTION
…tch to 3D Model Relative Path for STAMP_XL footprints

The relative paths appear to work on current latest KiCad 8.0.6, did not test with earlier.  Did text replacement to ensure minimum changes only.  
If you would like, I can also add both the RP2040 and RP2350 3D references to the regular stamp and set one as hidden.  Or, what KLC dictates, is to make a copy of the footprints and rename them to maintain the 1:1 relationship with the 3D Model (https://klc.kicad.org/symbol/s2/s2.3.html).